### PR TITLE
unlist headers

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -26,7 +26,7 @@ What is the essence/purpose of this course or module (2-3 sentences).
 knitr::include_graphics(c("assets/C-MOOR_Template/c-moor-logo-horizontal.png"))
 ```
 
-### Audience and Prerequisites {-}
+### Audience and Prerequisites {- .unlisted}
 
 What is the target audience?
 
@@ -50,7 +50,7 @@ The project portion of the module involves looking up genes in different databas
 -->
 
 
-### Format {-}
+### Format {- .unlisted}
 
 <!--
 Class Type should be one of the following (from CourseSource):
@@ -103,7 +103,7 @@ Another example:
 1. Goal 2
 1. Goal 3
 
-### Core Competencies {-}
+### Core Competencies {- .unlisted}
 
 This activity addresses the following core concepts and competencies:
 
@@ -183,7 +183,7 @@ Core concepts and competencies are taken from the following sources:
   - [Bioinformatics core competencies for undergraduate life sciences education](https://doi.org/10.1371/journal.pone.0196878) by [NIBLSE](https://qubeshub.org/community/groups/niblse)
 
 
-### C-MOOR Content Collection {-}
+### C-MOOR Content Collection {- .unlisted}
 
 ```{r, echo = FALSE, results='asis'}
 cow::borrow_chapter(


### PR DESCRIPTION
"unlisting" most of the headers in the About page (index.Rmd) so that they don't show up in the table of contents.  The TOC for the About page is automatically expanded to show lower level headers when you open the About page, and that pushes the rest of the TOC (with all the top level chapter titles) too far down the page.

Left the learning objectives listed because (a) they're the thing I care most about if I'm an instructor looking at this curriculum, and (b) it nudges people that there might be information they're interested in further down the page - it's not just a fluffy "About" section.